### PR TITLE
Fixes #30 - Fixes max fanspeed issue on apiV2018 devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     {
       "name": "naimo84",
       "email": "git@neumann-benjamin.de"
+    },
+    {
+      "name": "Patrick Brunier",
+      "email": "foss@brunier.nl"
     }
   ],
   "homepage": "https://github.com/naimo84/node-red-contrib-dyson-purelink",

--- a/src/dysonpurelink/device.ts
+++ b/src/dysonpurelink/device.ts
@@ -337,7 +337,7 @@ export class Device extends EventEmitter {
 
   setFanSpeed(value) {
     const fnsp = Math.round(value / 10)
-    this._setStatus({ fnsp: this._apiV2018 ? "000" + fnsp : fnsp })
+    this._setStatus({ fnsp: this._apiV2018 && fnsp < 10 ? "000" + fnsp : this._apiV2018 && fnsp === 10 ? "00" + fnsp : fnsp });
     return this.getFanSpeed()
   }
 


### PR DESCRIPTION
Old code always added a prefix of '000' to fnsp. Also when fnsp was 10, making it '00010' instead of '0010'.
Tested on DP04 if 0010 is indeed accepted. That is the case :)
Data sent to non-apiV2018 devices is still the same.